### PR TITLE
convert image to RGB in edit_anything_model.py

### DIFF
--- a/models/segment_models/edit_anything_model.py
+++ b/models/segment_models/edit_anything_model.py
@@ -58,7 +58,6 @@ class EditAnything:
 
     def semantic_class_w_mask(self, img_src, anns):
         image = Image.open(img_src)
-        if (image.mode == "RGBA"):
-            image = image.convert("RGB")
+        image = image.convert("RGB")
         image = resize_long_edge(image, 384)
         return self.region_level_semantic_api(image, anns)


### PR DESCRIPTION
When the input format is RGBA or grayscale,  the demo will fail. Add convert image to RGB in edit_anything_model.py to fix this issue